### PR TITLE
Updated node engine to 10.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"cors": "^2.8.0"
 	},
 	"engines": {
-		"node": "4.4.5"
+		"node": "10.15.1"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
 		"express": "^4.12.4",
 		"cors": "^2.8.0"
 	},
-	"engines": {
 		"node": "10.15.1"
 	},
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
 		"express": "^4.12.4",
 		"cors": "^2.8.0"
 	},
-		"node": "10.15.1"
 	"repository": {
 		"type": "git",
 		"url": "https://githost.com/camper/repo.git"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
 		"cors": "^2.8.0"
 	},
 		"node": "10.15.1"
-	},
 	"repository": {
 		"type": "git",
 		"url": "https://githost.com/camper/repo.git"


### PR DESCRIPTION
Npm was not able to install packages on heroku using node v4.4.5. Heroku recommended upgrading to at least 4.7.0.