### PR TITLE
fix: sync with example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # API Project: Timestamp Microservice for FCC
 
-### User stories :
+### User stories:
 
 1. The API endpoint is `GET [project_url]/api/timestamp/:date_string?`
 2. A date string is valid if can be successfully parsed by `new Date(date_string)` (JS) . Note that the unix timestamp needs to be an **integer** (not a string) specifying **milliseconds**. In our test we will use date strings compliant with ISO-8601 (e.g. `"2016-11-20"`) because this will ensure an UTC timestamp.
@@ -12,8 +12,8 @@ e.g. `{"unix": 1479663089000 ,"utc": "Sun, 20 Nov 2016 17:31:29 GMT"}`.
 5. If the date string is **invalid** the api returns a JSON having the structure `{"error" : "Invalid Date" }`.
 
 #### Example usage:
-* https://curse-arrow.hyperdev.space/api/timestamp/2015-12-15
-* https://curse-arrow.hyperdev.space/api/timestamp/1450137600000
+* https://curse-arrow.glitch.me/api/timestamp/2015-12-25
+* https://curse-arrow.glitch.me/api/timestamp/1451001600000
 
 #### Example output:
-* { "unix": 1450137600, "natural": "December 15, 2015" }
+* {"unix":1451001600000, "utc":"Fri, 25 Dec 2015 00:00:00 GMT"}

--- a/views/index.html
+++ b/views/index.html
@@ -6,7 +6,7 @@
       <title>Timestamp Microservice</title>
       <link rel="shortcut icon" href="https://cdn.hyperdev.com/us-east-1%3A52a203ff-088b-420f-81be-45bf559d01b1%2Ffavicon.ico" type="image/x-icon"/>
       <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
-      <link href="/public/style.css" rel="stylesheet" type="text/css">
+      <link href="style.css" rel="stylesheet" type="text/css">
    </head>
 
    <body>

--- a/views/index.html
+++ b/views/index.html
@@ -6,14 +6,14 @@
       <title>Timestamp Microservice</title>
       <link rel="shortcut icon" href="https://cdn.hyperdev.com/us-east-1%3A52a203ff-088b-420f-81be-45bf559d01b1%2Ffavicon.ico" type="image/x-icon"/>
       <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
-      <link href="style.css" rel="stylesheet" type="text/css">
+      <link href="/public/style.css" rel="stylesheet" type="text/css">
    </head>
 
    <body>
 
       <div class="container">
         <h2>API Project: Timestamp Microservice</h2>
-        <h3>User Stories :</h3>
+        <h3>User Stories:</h3>
         <ol class="user-stories">
           
           <li>The API endpoint is <code>GET [project_url]/api/timestamp/:date_string?</code></li>
@@ -30,8 +30,8 @@
 
         <h3>Example Usage:</h3>
         <ul>
-          <li><code>GET [project url]/api/timestamp/2015-12-25</code></li>
-          <li><code>GET [project url]/api/timestamp/1451001600000</code></li>
+          <li><a href="api/timestamp/2015-12-25">[project url]/api/timestamp/2015-12-25</a></li>
+          <li><a href="api/timestamp/1451001600000">[project url]/api/timestamp/1451001600000</a></li>
         </ul>
 
         <h3>Example Output:</h3>
@@ -41,7 +41,7 @@
       </div>
       <div class="footer">
         <p>
-          by <a href="http://www.freecodecamp.com/">freeCodeCamp</a> | <a href="https://hyperdev.com/#!/remix/FCC_API_timestamp_bplate/8338be2-a353-4892-8a0d-6295e4f12eb5">Click here to Remix</a>
+          by <a href="http://www.freecodecamp.com/">freeCodeCamp</a>
         </p>
       </div>
    </body>

--- a/views/index.html
+++ b/views/index.html
@@ -41,7 +41,7 @@
       </div>
       <div class="footer">
         <p>
-          by <a href="http://www.freecodecamp.com/">freeCodeCamp</a>
+          By <a href="https://www.freecodecamp.org/">freeCodeCamp</a>
         </p>
       </div>
    </body>


### PR DESCRIPTION
Syncs index.html and README.md with the example project at https://curse-arrow.glitch.me/.

Closes: https://github.com/freeCodeCamp/freeCodeCamp/issues/34626 based on comments @moT01 left in https://github.com/freeCodeCamp/boilerplate-project-timestamp/pull/19