### PR TITLE
fix: Remove engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
 		"express": "^4.12.4",
 		"cors": "^2.8.0"
 	},
-	"engines": {
-		"node": "4.4.5"
-	},
 	"repository": {
 		"type": "git",
 		"url": "https://githost.com/camper/repo.git"


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Removes the `engine` field from the `package.json` per http://github.com/freeCodeCamp/freeCodeCamp/issues/40365