### PR TITLE
fix: add dotenv package for environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,11 @@
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
 			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
+		"dotenv": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+			"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+		},
 		"destroy": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 	},
 	"dependencies": {
 		"express": "^4.12.4",
-		"cors": "^2.8.0"
+		"cors": "^2.8.0",
+		"dotenv": "^8.2.0"
 	},
 	"repository": {
 		"type": "git",

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 // where your node app starts
 
 // init project
+require('dotenv').config()
 var express = require('express');
 var app = express();
 

--- a/server.js
+++ b/server.js
@@ -6,6 +6,9 @@ require('dotenv').config()
 var express = require('express');
 var app = express();
 
+// Basic Configuration
+const port = process.env.PORT || 3000;
+
 // enable CORS (https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)
 // so that your API is remotely testable by FCC 
 var cors = require('cors');
@@ -28,6 +31,6 @@ app.get("/api/hello", function (req, res) {
 
 
 // listen for requests :)
-var listener = app.listen(process.env.PORT, function () {
+var listener = app.listen(port, function () {
   console.log('Your app is listening on port ' + listener.address().port);
 });


### PR DESCRIPTION
I have made two changes

1. Since the project is using .env file for fetching the port, it had no `dotenv` dependency. This creates confusion when `process.env.PORT` doesn't work. 
2. I have also added the `port` variable which sets the port to 3000 in case someone decides not to use the `.env` file.
I hope these changes help improve boilerplate.

