### PR TITLE
Rename server.js to index.js for replit debugging errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// server.js
+// index.js
 // where your node app starts
 
 // init project

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
 	"name": "fcc-api-projects-boilerplate",
 	"version": "0.0.1",
 	"description": "An FCC Backend Challenge",
-	"main": "server.js",
+	"main": "index.js",
 	"scripts": {
-		"start": "node server.js"
+		"start": "node index.js"
 	},
 	"dependencies": {
 		"express": "^4.12.4",

--- a/views/index.html
+++ b/views/index.html
@@ -14,8 +14,8 @@
     <div class="container">
       <h3>Example Usage:</h3>
       <ul>
-        <li><a href="api/timestamp/2015-12-25">[project url]/api/timestamp/2015-12-25</a></li>
-        <li><a href="api/timestamp/1451001600000">[project url]/api/timestamp/1451001600000</a></li>
+        <li><a href="api/2015-12-25">[project url]/api/2015-12-25</a></li>
+        <li><a href="api/1451001600000">[project url]/api/1451001600000</a></li>
       </ul>
 
       <h3>Example Output:</h3>


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

If campers clone the freeCodeCamp "Back End Development and APIs Projects" to Replit and try to debug their code - it will not work.

Replit debugging requires the "base" JS file to be named "index.js"

![image](https://user-images.githubusercontent.com/25173414/164246607-6bdbea49-b8c1-438a-b879-bdea6a00cd1f.png)

A pretty simple PR and if this approach is agreeable, I also would like to change:

- https://github.com/freeCodeCamp/boilerplate-project-headerparser/
- https://github.com/freeCodeCamp/boilerplate-project-urlshortener/
- https://github.com/freeCodeCamp/boilerplate-project-exercisetracker/
- https://github.com/freeCodeCamp/boilerplate-project-filemetadata/

To fix all 5 repo's at once - and to ensure standardisation :) 
