### PR TITLE
space in JSON example removed

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -25,7 +25,7 @@
     </div>
     <div class="footer">
       <p>
-        By <a href="https://github.com/will-s-205">William Step</a>
+        By <a href="https://www.freecodecamp.org/">freeCodeCamp.org</a>
       </p>
     </div>
   </body>

--- a/views/index.html
+++ b/views/index.html
@@ -25,7 +25,7 @@
     </div>
     <div class="footer">
       <p>
-        By <a href="https://www.freecodecamp.org/">freeCodeCamp.org</a>
+        By <a href="https://github.com/will-s-205">William Step</a>
       </p>
     </div>
   </body>

--- a/views/index.html
+++ b/views/index.html
@@ -20,7 +20,7 @@
 
       <h3>Example Output:</h3>
       <p>
-        <code>{"unix":1451001600000, "utc":"Fri, 25 Dec 2015 00:00:00 GMT"}</code>
+        <code>{"unix":1451001600000,"utc":"Fri, 25 Dec 2015 00:00:00 GMT"}</code>
       </p>
     </div>
     <div class="footer">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Hi everyone. This is my first Pull Request on a repository that is owned by the FCC team. I'm very happy to be here and I want to thank everyone for making people's dreams come through. 

As for my PR, I guess it's just a typo but it took a good chunk of my time to understand that JSON in example doesn't require to have a space between pairs. And because I'm a "genius" I've of course tried to reproduce this space in my JSON output. By any chance, can we make it without space? Thank you so much!
